### PR TITLE
QA-1017: chore(CODEOWNERS): correct git submodule path format

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,4 @@ package.json @mendersoftware/client-dependabot-reviewers
 package-lock.json @mendersoftware/client-dependabot-reviewers
 
 # Git submodules
-cJSON/ @mendersoftware/client-dependabot-reviewers
+/cJSON @mendersoftware/client-dependabot-reviewers


### PR DESCRIPTION
Fix git submodule entries in CODEOWNERS file to use correct path format.
Remove trailing slash and add leading slash to ensure rules are not ignored
by GitHub.

This corrects the format from 'submodule/' to '/submodule' for proper
path matching.